### PR TITLE
function name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arpoison"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["solidus"]
 readme = "README.md"
 license-file = "LICENSE"

--- a/src/args.rs
+++ b/src/args.rs
@@ -39,7 +39,7 @@ pub struct AppArgs {
 pub fn get_args() -> AppArgs {
     let matches: ArgMatches = App::new("ARPoison")
         .author("solidus")
-        .version("0.1.0")
+        .version("0.1.1")
         .about("A simple tool to send spoofed ARP packets to poison a victim's cache")
         .arg(Arg::with_name("target")
             .long("target")

--- a/src/link.rs
+++ b/src/link.rs
@@ -28,7 +28,7 @@ impl ArpoisonReply {
         }
     }
 
-    pub fn tcpdump_output(&self) {
+    pub fn print_is_at(&self) {
         println!(
             "{} -> {} {} is-at {}",
             format!("{}", &self.mac).bright_yellow().on_black(),
@@ -81,7 +81,7 @@ pub fn send_arp_loop<'a>(interface: &'a datalink::NetworkInterface,
     ethernet_frame.set_payload(arp_packet.packet_mut());
 
     loop {
-        reply.tcpdump_output();
+        reply.print_is_at();
         tx.send_to(&ethernet_frame.packet_mut(), None);
         thread::sleep(time::Duration::from_millis(1_500))
     }


### PR DESCRIPTION
- "tcpdump_output" was misleading, as tcpdump isn't used. Function is now called
  "print_is_at" since it prints the "is-at" syntax, SIMILAR to tcpdump's output ;)